### PR TITLE
Replace raphaelJS with SVGjs

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -10,6 +10,24 @@ body {
   background-color: black;
 }
 
+.proxy {
+  position: absolute;
+  visibility: hidden;
+  height: 1%;
+  width: 1%;
+}
+
+.clickable {
+  overflow: hidden;
+  position: absolute;
+}
+
+.cranyon {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+}
+
 .pic-container {
   position: absolute;
   height: 100%;
@@ -18,9 +36,6 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  display: flex;
-  justify-content: center;  /* center horizontal */
-  align-items: center;      /* center vertical */
 }
 
 .builder-loading {
@@ -65,18 +80,3 @@ body {
   background: #171717;
   transition: background 0.5s, opacity 0.5s, visibility 0.5s;
 }
-
-.letterbox {
-  z-index: -999;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  background-color: #171717;
-  background-blend-mode: overlay;
-  background-size: cover;
-  filter: blur(2px);
-  -webkit-filter: blur(2px);
-}
-

--- a/assets/index.ejs
+++ b/assets/index.ejs
@@ -5,20 +5,21 @@
   <meta name="viewport" id="viewport" content="width=device-width, initial-scale=1.0">
   <link rel='shortcut icon' href='<%= htmlWebpackPlugin.options.baseIconURL %>/favicon.ico' />
   <style type="text/css">
-    .initial-spinner {
-      opacity: 1; 
+    .load-spinner {
+      opacity: .4; 
       position: fixed; 
       width: 100%; 
       height: 100%; 
       top: 0; 
       left: 0; 
+      z-index: 999;
       background: url('<%= htmlWebpackPlugin.options.baseIconURL %>/load.gif') center center no-repeat rgb(45, 45, 45); 
     }
   </style>
   <title></title>
 </head>
 <body>
-  <div class="initial-spinner"></div>
+  <div class="load-spinner"></div>
   <pf-builder></pf-builder>
   <pf-menu></pf-menu>
 </body>

--- a/assets/js/directives/clickables-directive.js
+++ b/assets/js/directives/clickables-directive.js
@@ -1,0 +1,136 @@
+/**
+ * @overview Element responsible for style and behavior of clickable
+ * @module   clickables-directive
+ */
+
+'use strict';
+
+/**
+ * Directive controller
+ * @class
+ */
+class ClickablesCtrl {
+  /**
+   * Directive constructor
+   */
+  constructor($window, $compile, $scope, ClickablesService, Cranyons) {
+    this.window = $window;
+    this.scope  = $scope;
+    this.compile = $compile;
+    
+    this.Service = ClickablesService
+    this.CranyonService = Cranyons;
+
+    this.document = this.window.document;
+  }
+
+  onClickableClick(id) {
+    this.CranyonService.setLoading(true);
+    this.CranyonService.clickableClicked.call(this.CranyonService, id);
+  }
+}
+
+function link(scope, element, attributes, Ctrl) {
+  const winJQL = angular.element(Ctrl.window);
+
+  function setupClickables() {
+    const windowDimensions = {
+      x: Ctrl.window.innerWidth,
+      y: Ctrl.window.innerHeight
+    }
+
+    const imgTag = Ctrl.document.getElementById('prxy-' + Ctrl.cranyon.id);
+    const imgDimensions = Ctrl.Service.getImgSize(imgTag);
+
+    const clickablesContainerStyles = Ctrl.Service.createContainerStyles({ windowDimensions, imgDimensions });
+    element.css(clickablesContainerStyles);
+
+    Ctrl.svgDocument = Ctrl.Service.createSVGDocument(Ctrl.cranyon.id);
+
+    Ctrl.clickables = Ctrl.Service.drawClickables({ 
+      clickables: Ctrl.cranyon.clickables, 
+      imgDimensions, 
+      sVGdocument: Ctrl.svgDocument,
+      windowDimensions 
+    });
+
+    // Bind click actions to clickables
+    Ctrl.clickables.map(set => {
+      const elementWithOnClick = set.last().node;
+      const cranyonID = set.last().attr('cranyon');
+
+      const $element = angular.element(elementWithOnClick);
+        
+      $element.attr('ng-click', 'ctrl.onClickableClick("' + cranyonID + '")');
+      scope.$applyAsync(Ctrl.compile($element)(scope));
+    })
+  }
+
+  // Draw clickables only AFTER image has loaded
+  Ctrl.scope.$watch(
+    () => Ctrl.isImgVisible,
+    newIsImgVisible => {
+      // Cranyon is active
+      if (newIsImgVisible) {
+        // check if these clickables already exist for this screen size
+        if (!Ctrl.Service.documentsMap.get(Ctrl.cranyon.id)) {
+          if (Ctrl.svgDocument) {
+            Ctrl.svgDocument.remove();
+          }
+          setupClickables();
+        }
+        Ctrl.CranyonService.setLoading(false);
+
+        // rebind window resize listener
+        if (Ctrl.bindResize) {
+          Ctrl.bindResize();
+        }
+      }
+    }
+  );
+
+  // Covers edge case where this directive enters link phase
+  // AFTER <img> has loaded
+  if(Ctrl.isImgVisible) {
+    Ctrl.inactivateWatch();
+    setupClickables();
+  }
+
+  Ctrl.bindResize = () => {
+    // clear previous resize bindings i.e. all other cranyons' bindings
+    winJQL.unbind('resize');
+    // set this cranyon to resize if window is resized
+    winJQL.bind('resize', () => {
+      if (Ctrl.isActive) {
+        // clear Clickables and the SVG document;
+        Ctrl.svgDocument.remove();
+        Ctrl.Service.documentsMap.clear();
+        setupClickables();
+      }
+    });
+  };
+
+  Ctrl.bindResize();
+}
+
+/**
+ * Specify dependencies to be injected
+ */
+ClickablesCtrl.$inject = ['$window', '$compile', '$scope', 'ClickablesService', 'Cranyons'];
+
+function Clickables() {
+  return {
+    controller: ClickablesCtrl,
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      cranyon: '=',
+      isImgVisible: '=',
+      isActive: '='
+    },
+    link,
+    restrict: 'E'
+  };
+}
+
+export default Clickables;

--- a/assets/js/directives/cranyon-directive.js
+++ b/assets/js/directives/cranyon-directive.js
@@ -6,20 +6,8 @@
 'use strict';
 
 import angular from 'angular';
-import Raphael from 'raphael';
 
 import cranyonTemplate from '../../templates/cranyon-directive.html';
-
-const greatorStyle = {
-  width: 'auto',
-  height: '100%',
-  maxWidth: '100%'
-};
-const lessorStyle = {
-  width: "100%",
-  height: "auto",
-  maxHeight: "100%"
-}
 
 /**
  * Directive controller
@@ -31,13 +19,11 @@ class CranyonCtrl {
    * @param  {Object} $window    AngularJS wrapper of browser object
    * @param  {Object} $scope     AngularJS scope object
    * @param  {Object} Cranyons   Service providing Cranyon utility methods
-   * @param  {Object} Draw       Service providing methods to assist in drawing clickables
    */
-  constructor($window, $scope, Cranyons, Draw) {
+  constructor($window, $scope, Cranyons) {
     this.window         = $window; 
     this.scope          = $scope;
     this.CranyonService = Cranyons;
-    this.DrawService    = Draw;
 
     this.document = this.window.document;
 
@@ -58,13 +44,6 @@ class CranyonCtrl {
   }
 
   imageLoaded() {
-    // fade app's initial load spinner if this is the inital load of app
-    if (this.CranyonService.isInitialLoad) {
-      this.document.querySelector('.initial-spinner').style.visibility = "hidden";
-      this.CranyonService.isInitialLoad = false;
-    }
-
-    this.clearClickables();
     this.CranyonService.inactivateCurrent.call(this.CranyonService);
     this.CranyonService.activeCranyon = this.cranyon.id;
 
@@ -72,10 +51,7 @@ class CranyonCtrl {
     // update the browser history state with this state
     this.window.history.replaceState({id: this.cranyon.id}, '', '');
 
-    this.CranyonService.setBackgroundImage(this.imageSrc);
     this.setIsActive(true);
-    this.scope.$apply();
-    this.init();
   }
 
   imageNotFound() {
@@ -102,93 +78,46 @@ class CranyonCtrl {
     this.document.title = 'Cranyons - ' + this.cranyon.name;
   }
 
-  computeWindowRatio() {
-    return this.window.innerWidth / this.window.innerHeight;
-  }
-
-  isWindowGreatorAspect() {
-    return this.computeWindowRatio() >= this.cranyon.aspectRatio;
-  }
-
-  clearClickables() {
-    this.DrawService.clearClickables();
-  }
-
-  /**
-   * Setup raphael paper space and add clickables to it  
-   */
-  init() {
-    const clickables = this.cranyon.clickables;
-    const imgtag     = this.document.getElementById(this.cranyon.id);
-    const window     = angular.element(this.window)[0];
-
-    const imgWidth  = imgtag.clientWidth;
-    const imgHeight = imgtag.clientHeight;
-    const winWidth  = window.innerWidth;
-    const winHeight = window.innerHeight;
-
-    // draw canvas
-    this.paper = new Raphael(((winWidth/2)-(imgWidth/2)), ((winHeight/2)-(imgHeight/2)), imgWidth, imgHeight);
-    this.DrawService.drawClickables(this.paper, clickables, {width: imgWidth, height: imgHeight}, this);
-    this.CranyonService.isLoading(false);
-    this.scope.$apply();
-  }
-
-  onClickableClick(id) {
-    this.CranyonService.isLoading(true);
-    this.CranyonService.clickableClicked.call(this.CranyonService, id, this.cranyon);
-  }
-
   setIsActive(value) {
-    this.isActive = value;
+    // Need two separate digest cycles here 
+    // to avoid drawing clickables before img appears
+    //    
+    // show image
+    this.scope.$applyAsync(() => this.isActive = value);
+    // draw clickables
+    this.scope.$applyAsync(() => this.isImgVisible = value);
   }
 }
 
-function link(scope, element, attributes, CranyonCtrl) {
-  const imgJQL = element.find('img');
-  const winJQL = angular.element(CranyonCtrl.window);
+function link(scope, element, attributes, Ctrl) {
+  const $section = element.find('section');
 
-  function setImgStyle() {
-    if (CranyonCtrl.isWindowGreatorAspect()) {
-      imgJQL.css(greatorStyle);
-    } else {
-      imgJQL.css(lessorStyle);
-    }
-  }
-
-  CranyonCtrl.resize = () => {
-    // clear previous resize bindings
-    winJQL.unbind('resize');
-    // set this cranyon to resize if window is resized
-    winJQL.bind('resize', () => {
-      if (CranyonCtrl.isActive) {
-        CranyonCtrl.clearClickables();
-      }
-      setImgStyle();
-      if (CranyonCtrl.isActive) {
-        CranyonCtrl.imageLoaded();
-      }
-    });
+  const cranyonBackground = {
+    backgroundImage: 'url(' + Ctrl.imageSrc + '), url(' + Ctrl.imageSrc + ')',
+    backgroundSize: 'contain, cover',
+    backgroundRepeat: 'no-repeat, no-repeat',
+    backgroundPosition: 'center center',
+    backgroundColor: '#171717',
+    backgroundBlendMode: 'normal, overlay'
   };
 
-  CranyonCtrl.resize();
-  setImgStyle();
+  $section.css(cranyonBackground);
 }
 
 /**
  * Specify dependencies to be injected
  */
-CranyonCtrl.$inject = ['$window', '$scope', 'Cranyons', 'Draw'];
+CranyonCtrl.$inject = ['$window', '$scope', 'Cranyons'];
 
 function Cranyon() {
   return {
     controller: CranyonCtrl,
-    controllerAs: 'cranyon',
+    controllerAs: 'ctrl',
     bindToController: true,
     scope: {
       cranyon: '='
     },
-    link: link,
+    link,
     restrict: 'E',
     template: cranyonTemplate
   };

--- a/assets/js/directives/index.js
+++ b/assets/js/directives/index.js
@@ -3,12 +3,14 @@
 import angular from 'angular';
 
 import Cranyon      from './cranyon-directive';
+import Clickables    from './clickables-directive';
 import ImagesLoaded from './images-loaded-directive';
 import Builder      from './builder-directive';
 import Menu         from './menu-directive';
 
 export default angular.module('app.directives', [])
   .directive('pfCranyon', Cranyon)
+  .directive('pfClickables', Clickables)
   .directive('pfImagesLoaded', ImagesLoaded)
   .directive('pfBuilder', Builder)
   .directive('pfMenu', Menu);

--- a/assets/js/services/clickables-service.js
+++ b/assets/js/services/clickables-service.js
@@ -1,0 +1,117 @@
+/**
+ * @overview Provides Clickables helper methods
+ * @module   clickables-service
+ */
+
+'use strict';
+
+/**
+ * Clickables service object for factory call
+ */
+class ClickablesService {
+  /**
+   * Service constructor
+   */
+  constructor(Draw) {
+    this.Draw = Draw;
+
+    this.documentsMap = new Map();
+  }
+
+  getImgSize(imgTag) {
+    return {
+      x: imgTag.naturalWidth,
+      y: imgTag.naturalHeight
+    };
+  }
+
+  isWindowGreatorAspect({ windowDimensions, imgDimensions }) {
+    const imgAspect = imgDimensions.x / imgDimensions.y;
+    const windowAspect = windowDimensions.x / windowDimensions.y;
+
+    return windowAspect >= imgAspect;
+  }
+
+  getScaledImgDimensions({ imgDimensions, windowDimensions }) {
+    let imgScale;
+
+    if (this.isWindowGreatorAspect({ windowDimensions, imgDimensions })) {
+      imgScale = windowDimensions.y / imgDimensions.y;
+    }
+    else {
+      imgScale = windowDimensions.x / imgDimensions.x;
+    }
+
+    return {
+      x: imgDimensions.x * imgScale,
+      y: imgDimensions.y * imgScale
+    }
+  }
+
+  createContainerStyles({ windowDimensions, imgDimensions }) {
+    let clickablesContainerStyles;
+    let imgScale;
+
+    if (this.isWindowGreatorAspect({ windowDimensions, imgDimensions })) {
+      imgScale = windowDimensions.y / imgDimensions.y;
+
+      const scaledImgWidth = imgDimensions.x * imgScale;
+
+      let letterBoxWidth = (windowDimensions.x - scaledImgWidth) / 2;
+      letterBoxWidth += 'px';
+
+      clickablesContainerStyles = {
+        height: '100%',
+        left: letterBoxWidth,
+        right: letterBoxWidth,
+        width: '',
+        top: '',
+        bottom: ''
+      };
+    }
+    else {
+      imgScale = windowDimensions.x / imgDimensions.x;
+      
+      const scaledImgHeight = imgDimensions.y * imgScale;
+
+      let letterBoxHeight = (windowDimensions.y - scaledImgHeight) / 2;
+      letterBoxHeight += 'px';
+
+      clickablesContainerStyles = {
+        width: '100%',
+        top: letterBoxHeight,
+        bottom: letterBoxHeight,
+        height: '',
+        left: '',
+        right: ''
+      };
+    }
+
+    return clickablesContainerStyles;
+  }
+
+  createSVGDocument(id) {
+    const hostElementID = 'cryn-' + id;
+
+    const newDocument = this.Draw.createSVGDocument(hostElementID);
+
+    this.documentsMap.set(id, newDocument);
+
+    return newDocument;
+  }
+
+  drawClickables({ clickables, imgDimensions, sVGdocument, windowDimensions }) {
+    const scaledImgDimensions = this.getScaledImgDimensions({ imgDimensions, windowDimensions });
+
+    return clickables.map(
+      clickable => this.Draw.createClickable({ document: sVGdocument, clickable, imgDimensions: scaledImgDimensions })
+    );
+  }
+}
+
+/**
+ * Specify dependencies to be injected
+ */
+ClickablesService.$inject = ['Draw'];
+
+export default ClickablesService;

--- a/assets/js/services/cranyon-service.js
+++ b/assets/js/services/cranyon-service.js
@@ -23,8 +23,7 @@ class CranyonService {
 
     this.cranyonsQueue = [];
 
-    this.loading = true;
-    this.isInitialLoad = true;
+    this.loadSpinner = this.window.document.querySelector('.load-spinner')
 
     this.futureCranyons = new Map();
     this.cranyonHistory = new Map();
@@ -116,6 +115,7 @@ class CranyonService {
   }
 
   clickableClicked(clickableID, currentCranyon) {
+    currentCranyon = currentCranyon || this.getActiveCranyonCtrl().cranyon;
     const cranyonUpNext = this.futureCranyons.get(currentCranyon.id).get(clickableID);
 
     this.window.history.pushState({id: cranyonUpNext.id}, '', '/' + cranyonUpNext.url);
@@ -123,7 +123,6 @@ class CranyonService {
     if (this.hasAlreadySeenThis(cranyonUpNext.id)) {
       const cranyonUpNextCtrl = this.cranyonHistory.get(cranyonUpNext.id);
       cranyonUpNextCtrl.imageLoaded();
-      cranyonUpNextCtrl.resize();
     }
     // haven't been to this cranyon yet
     else {
@@ -143,13 +142,8 @@ class CranyonService {
     return this.cranyonHistory.get(this.activeCranyon);
   }
 
-  setBackgroundImage(imageSrc) {
-    const el = this.window.document.querySelector('.letterbox')
-    el.style.backgroundImage = 'url("' + imageSrc + '")';
-  }
-
   backAction(rootscope, id) {
-    this.isLoading(true);
+    this.setLoading(true);
 
     const currentCranyonCtrl = this.getActiveCranyonCtrl();
     const nextCranyonCtrl = this.cranyonHistory.get(id);
@@ -157,7 +151,6 @@ class CranyonService {
     // Next cranyon exists in app cache
     if (nextCranyonCtrl) {
       nextCranyonCtrl.imageLoaded();
-      nextCranyonCtrl.resize();
     } 
 
     // Does not exist in app cache
@@ -176,8 +169,13 @@ class CranyonService {
     this.unregister(cranyonID);
   }
 
-  isLoading(loading) {
-    this.loading = loading;
+  setLoading(isLoading) {
+    if (isLoading) {
+      this.loadSpinner.style.visibility = 'visible';
+    }
+    else {
+      this.loadSpinner.style.visibility = 'hidden';
+    }
   }
 
   hasAlreadySeenThis(id) {

--- a/assets/js/services/index.js
+++ b/assets/js/services/index.js
@@ -2,9 +2,11 @@
 
 import angular from 'angular';
 
-import CranyonService from './cranyon-service';
-import DrawService    from './draw-service';
+import CranyonService    from './cranyon-service';
+import DrawService       from './draw-service';
+import ClickablesService from './clickables-service';
 
 export default angular.module('app.services', [])
   .service('Cranyons', CranyonService)
-  .service('Draw', DrawService);
+  .service('Draw', DrawService)
+  .service('ClickablesService', ClickablesService);

--- a/assets/templates/builder-directive.html
+++ b/assets/templates/builder-directive.html
@@ -1,5 +1,3 @@
 <div>
   <pf-cranyon ng-repeat='cranyon in builder.Cranyons.cranyonsQueue' cranyon='cranyon'></pf-cranyon>
-  <div ng-show='builder.Cranyons.loading' class='builder-loading animate-show'></div>
-  <div class='letterbox'></div>
 </div>

--- a/assets/templates/cranyon-directive.html
+++ b/assets/templates/cranyon-directive.html
@@ -1,3 +1,21 @@
-<div class='pic-container' pf-images-loaded='cranyon.loaded'>
-  <img ng-attr-id='{{ cranyon.cranyon.id }}' ng-show='cranyon.isActive' ng-src='{{cranyon.imageSrc}}'></img>
+<div
+  class='pic-container'
+  pf-images-loaded='ctrl.loaded'
+  ng-show='ctrl.isActive'
+> 
+  <!-- proxy is for triggering image-loaded event -->
+  <img 
+    class='proxy'
+    ng-attr-id='prxy-{{ ctrl.cranyon.id }}' 
+    ng-src='{{ ctrl.imageSrc }}' 
+  >
+  <section class='cranyon'>
+    <pf-clickables
+      class='clickable'
+      ng-attr-id='cryn-{{ ctrl.cranyon.id }}'
+      is-active='ctrl.isActive'
+      is-img-visible='ctrl.isImgVisible' 
+      cranyon='ctrl.cranyon'
+    ></pf-clickables>
+  </section>
 </div>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "imagesloaded": "^4.1.0",
     "mongojs": "^1.3.0",
     "nconf": "^0.8.4",
-    "raphael": "^2.1.4"
+    "svgjs": "^2.2.5"
   },
   "devDependencies": {
     "babel-core": "^6.10.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ const plugins = [
   }),
   new CommonsChunkPlugin({
     name: 'vendor',
-    filename: '[name].[hash].bundle.js',
+    filename: '[name].[hash].js',
     minChunks: Infinity
   }),
   new DefinePlugin(replacements)
@@ -71,7 +71,7 @@ module.exports = {
       'angular',
       'axios',
       'angular-animate',
-      'raphael',
+      'svgjs',
       'imagesloaded'
     ]
   },


### PR DESCRIPTION
refactoring clickables: added SVGjs dependency, added clickables directive

refactoring clickables: moved logic around for better organization, refactored cranyon image to auto center/size according to viewport shape/size, lots of styles-based refactorings

refactoring clickables: implemented SVG document sizing in the case where the viewport/window has a greater aspect ratio than the cranyon image, moved around some things related to clickables

finished implementing SVG document resizing when viewport/window has a lesser aspect ratio than the cranyon image

refactoring clickables: fixed window resize callback to remove current SVG document before creating a new one, factored out most of clickables directive link function logic into a new service

prototyped clickHandling injection on SVGs

reimplemented clickable drawing algorithm

added 'glow' characteristic to clickables path

added clickables fadein/fadeout animation

added the dynamic binding of click handler to svg clickables

debugging clickable back action

back action now works, implemented proper window resize algorithm to account for the clickables on each cached cranyon

fixed back action bug where window resizing action wasn't being rebound

added dynamic styles to include letterbox cranyon background as a part of each cranyon component rather than as a separate shared component

finished refactoring letterbox backgrounds to be part of the cranyon components

refactored load spinner strategy to use the load spinner that is outside of the angular application
