### PR TITLE
added 'critical' logic to load the initial image ASAP and to show it …

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -19,6 +19,15 @@ body {
   position: absolute;
   height: 100%;
   width: 100%;
+  background-size: contain, cover;
+  background-repeat: no-repeat, no-repeat;
+  background-position: center center;
+  background-color: #171717;
+  background-blend-mode: normal, overlay;
+}
+
+.initial-disappear {
+  transition: visibility 2s;
 }
 
 .pic-container {
@@ -32,7 +41,7 @@ body {
 }
 
 .animate-show.ng-hide-add, .animate-show.ng-hide-remove {
-  transition: background 0.3s, opacity 0.3s, visibility 0.3s;
+  transition: background 1s, opacity 1s, visibility 1s;
 }
 
 .animate-show.ng-hide {

--- a/assets/index.ejs
+++ b/assets/index.ejs
@@ -1,26 +1,50 @@
 <!DOCTYPE html>
 <html ng-app='app'>
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" id="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel='shortcut icon' href='<%= htmlWebpackPlugin.options.baseIconURL %>/favicon.ico' />
-  <style type="text/css">
-    .load-spinner {
-      opacity: .5; 
-      position: fixed; 
-      width: 100%; 
-      height: 100%; 
-      top: 0; 
-      left: 0; 
-      z-index: 999;
-      background: url('<%= htmlWebpackPlugin.options.baseIconURL %>/load.gif') center center no-repeat rgb(45, 45, 45);
-      transition: opacity .5s ease-in-out, visibility .5s; 
-    }
-  </style>
-  <title></title>
-</head>
-<body>
-  <div class="load-spinner"></div>
-  <app></app>
-</body>
+  <head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' id='viewport' content='width=device-width, initial-scale=1.0'>
+    <link rel='shortcut icon' href='<%= htmlWebpackPlugin.options.baseIconURL %>/favicon.ico' />
+    <style>
+      .load-spinner {
+        opacity: .5; 
+        position: fixed; 
+        width: 100%; 
+        height: 100%; 
+        top: 0; 
+        left: 0; 
+        z-index: 999;
+        background: url('<%= htmlWebpackPlugin.options.baseIconURL %>/load.gif') center center no-repeat;
+        transition: opacity .5s ease-in-out, visibility .5s; 
+      }
+    </style>
+    <script>
+      window.cranyons = {
+        domains: <%= htmlWebpackPlugin.options.domains %>,
+        cache: []
+      };
+      window.cranyons.domain = window.innerWidth > 700 
+        ? window.cranyons.domains.MAIN 
+        : window.cranyons.domains.MOBILE;
+      window.cranyons.cache.push(new Image());
+      window.cranyons.cache.push(new Image());
+      window.cranyons.name = window.location.pathname.split('/')[1];
+      window.cranyons.cache[0].src = window.cranyons.name
+        ? window.cranyons.domain + window.cranyons.name.toLowerCase() + '.jpg'
+        : window.cranyons.domain + '<%= htmlWebpackPlugin.options.initialCranyonPath %>';
+      window.cranyons.cache[0].onload = function() {
+        var initialCranyon = document.getElementById('initial-cranyon');
+        var initialCranyonURL = 'url(' + window.cranyons.cache[0].src + ')';
+        initialCranyon.style.backgroundImage =  initialCranyonURL + ', ' + initialCranyonURL;
+      };
+      window.cranyons.cache[1].src = '<%= htmlWebpackPlugin.options.baseIconURL %>/menu4.svg';
+    </script>
+    <title></title>
+  </head>
+  <body>
+    <div class='load-spinner'></div>
+    <div class='pic-container animate-show'> 
+      <section id='initial-cranyon' class='cranyon initial-disappear'></section>
+    </div>
+    <app></app>
+  </body>
 </html>

--- a/assets/js/directives/cranyon-directive.js
+++ b/assets/js/directives/cranyon-directive.js
@@ -48,6 +48,13 @@ class CranyonCtrl {
     this.window.history.replaceState({id: this.cranyon.id}, '', '');
 
     this.setIsActive(true);
+
+    // if this is the initial cranyon, remove the filler image
+    if (this.CranyonService.initialLoad) {
+      this.CranyonService.initialLoad = false;
+      const initialCranyon = this.document.getElementById('initial-cranyon');
+      initialCranyon.style.visibility = 'hidden';
+    }
   }
 
   imageNotFound() {
@@ -89,12 +96,7 @@ function link(scope, element, attributes, Ctrl) {
   const $section = element.find('section');
 
   const cranyonBackground = {
-    backgroundImage: 'url(' + Ctrl.imageSrc + '), url(' + Ctrl.imageSrc + ')',
-    backgroundSize: 'contain, cover',
-    backgroundRepeat: 'no-repeat, no-repeat',
-    backgroundPosition: 'center center',
-    backgroundColor: '#171717',
-    backgroundBlendMode: 'normal, overlay'
+    backgroundImage: 'url(' + Ctrl.imageSrc + '), url(' + Ctrl.imageSrc + ')'
   };
 
   function verifyImgLoaded(img) {

--- a/assets/js/services/cranyon-service.js
+++ b/assets/js/services/cranyon-service.js
@@ -24,6 +24,7 @@ class CranyonService {
     this.cranyonsQueue = [];
 
     this.loadSpinner = this.window.document.querySelector('.load-spinner')
+    this.initialLoad = true;
 
     this.futureCranyons = new Map();
     this.cranyonHistory = new Map();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,9 @@ const plugins = [
     template: __dirname + '/assets/index.ejs',
     filename: '../index.html',
     inject: 'body',
-    baseIconURL: envConfig.get('BASE_ICON_URL')
+    baseIconURL: envConfig.get('BASE_ICON_URL'),
+    domains: JSON.stringify(constants.PICS_DOMAIN),
+    initialCranyonPath: constants.INITIAL_CRANYON.image
   }),
   new CommonsChunkPlugin({
     name: 'vendor',


### PR DESCRIPTION
…as soon as it loads and to be replaced with the real cranyon when the full angular app is finished bootstrapping

added 'critical' support for arbitrary endpoint requests
